### PR TITLE
Upgrading to use Dropwizard 0.8.1 dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+0.8.1
+ - upgraded to dropwizard:0.8.1 depedencies
+
 0.0.0
 
  - project start
+ - dropwizard:0.7.1 compatible

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## dropwizard-statsd
 
-A Dropwizard 0.7 ReporterFactory that wraps [jjagged/metrics-statsd](https://github.com/jjagged/metrics-statsd). 
+A Dropwizard ReporterFactory that wraps [jjagged/metrics-statsd](https://github.com/jjagged/metrics-statsd). 
 
 ### Adding a reporter
 
@@ -18,6 +18,13 @@ metrics:
 
 
 ### Add a dependency
+
+There are 2 releases of this JAR, one that brings in dropwizard:0.7.1 dependencies and one that brings in dropwizard:0.8.1 dependencies.  Pick the version of this JAR appropriate to your Dropwizard project:
+
+| dropwizard-statsd version | dropwizard-version |
+|---------------------------|--------------------|
+| 0.0.0                     | 0.7.1              |
+| 0.8.1                     | 0.8.1              |
 
 The distribution is hosted on [bintray](https://bintray.com/dehora/maven/dropwizard-statsd/view). To use the reporter,add jcenter to your dependencies. For example in Gradle - 
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ allprojects {
     pkg {
       repo = 'maven'
       name = 'dropwizard-statsd'
-      desc = 'a statsd recorder factory for dropwizard 0.7'
+      desc = 'a statsd recorder factory for dropwizard'
       websiteUrl = 'https://github.com/dehora/dropwizard-statsd'
       issueTrackerUrl = 'https://github.com/dehora/dropwizard-statsd/issues'
       vcsUrl = 'https://github.com/dehora/dropwizard-statsd.git'
@@ -62,7 +62,7 @@ subprojects {
       published
     }
     dependencies {
-      testCompile 'junit:junit:4.7'
+      testCompile 'junit:junit:4.11'
     }
     task sourceJar(type: Jar) {
       from sourceSets.main.allSource

--- a/dropwizard-statsd/build.gradle
+++ b/dropwizard-statsd/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compile 'com.github.jjagged:metrics-statsd:1.0.0'
-  compile 'io.dropwizard:dropwizard-core:0.7.1'
-  compile 'io.dropwizard:dropwizard-metrics:0.7.1'
+  compile 'io.dropwizard:dropwizard-core:0.8.1'
+  compile 'io.dropwizard:dropwizard-metrics:0.8.1'
   testCompile 'junit:junit:4.11'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version: 0.0.0
+version: 0.8.1
 
 group: net.dehora.dropwizard
 


### PR DESCRIPTION
Hi - 

Would you mind merging & releasing the 0.8.1 version up to bintray repo?  This is a pretty minor change - it just brings in the latest dropwizard 0.8.1 dependencies instead of the original 0.7.1.

Thanks!
Tom
