### PR TITLE
Simple dependency upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/.nb-gradle/profiles/private/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
+0.9.1
+ - upgraded to dropwizard:0.9.1 dependencies
+ - upgraded junit from 4.11 -> 4.12
+
 0.8.1
- - upgraded to dropwizard:0.8.1 depedencies
+ - upgraded to dropwizard:0.8.1 dependencies
 
 0.0.0
 

--- a/README.md
+++ b/README.md
@@ -19,12 +19,13 @@ metrics:
 
 ### Add a dependency
 
-There are 2 releases of this JAR, one that brings in dropwizard:0.7.1 dependencies and one that brings in dropwizard:0.8.1 dependencies.  Pick the version of this JAR appropriate to your Dropwizard project:
+There are 3 releases of this JAR, one that brings in dropwizard:0.7.1, one for dropwizard:0.8.1 and one for dropwizard:0.9.1.  Pick the version of this JAR appropriate to your Dropwizard project:
 
 | dropwizard-statsd version | dropwizard-version |
 |---------------------------|--------------------|
 | 0.0.0                     | 0.7.1              |
 | 0.8.1                     | 0.8.1              |
+| 0.9.1                     | 0.9.1              |
 
 The distribution is hosted on [bintray](https://bintray.com/dehora/maven/dropwizard-statsd/view). To use the reporter,add jcenter to your dependencies. For example in Gradle - 
 

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ subprojects {
       published
     }
     dependencies {
-      testCompile 'junit:junit:4.11'
+      testCompile 'junit:junit:4.12'
     }
     task sourceJar(type: Jar) {
       from sourceSets.main.allSource

--- a/dropwizard-statsd/build.gradle
+++ b/dropwizard-statsd/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
   compile 'com.github.jjagged:metrics-statsd:1.0.0'
-  compile 'io.dropwizard:dropwizard-core:0.8.1'
-  compile 'io.dropwizard:dropwizard-metrics:0.8.1'
-  testCompile 'junit:junit:4.11'
+  compile 'io.dropwizard:dropwizard-core:0.9.1'
+  compile 'io.dropwizard:dropwizard-metrics:0.9.1'
+  testCompile 'junit:junit:4.12'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version: 0.8.1
+version: 0.9.1
 
 group: net.dehora.dropwizard
 


### PR DESCRIPTION
Hi!  This PR just moves the dependencies in this JAR up to dropwizard:0.9.1-compatible versions to avoid potential conflicts with older transitive dependencies coming in to a newer dropwizard-0.9.1 project

I didn't find the need to upgrade any actual code, which is nice.

I also don't have the bintray credentials to "release" this, so if you like what you see and accept the Pull Request, can you also release a new 0.9.1 JAR to bintray?

Thanks!
Tom
